### PR TITLE
Converts to standalone commands via console_scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Monitoring daemon (via subreddit's /new feed):
 ### Running Moderator Bot
 
 ```
-$ python -m tor.main
+$ tor-moderator
 # => [daemon mode + logging]
 ```
 
@@ -61,7 +61,7 @@ Monitoring daemon (via Redis queue):
 ### Running Apprentice Bot
 
 ```
-$ python -m tor.ocr
+$ tor-apprentice
 # => [daemon mode + logging]
 ```
 
@@ -78,7 +78,7 @@ Monitoring daemon (via subreddit's /new feed):
 ### Running Archiver Bot
 
 ```
-$ python -m tor.archiver
+$ tor-archivist
 # => [daemon mode + logging]
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ be, though there are some external requirements.
 > contains such information as the useragents and various secrets. It is built
 > for Python 3.6.
 
+## Installation
+
+```
+$ git clone https://github.com/TranscribersOfReddit/TranscribersOfReddit.git tor
+$ pip install tor/
+```
+
+OR
+
+```
+$ pip install 'git+https://github.com/TranscribersOfReddit/TranscribersOfReddit.git@master#egg=tor'
+```
+
 ## Moderator Bot (`/u/transcribersofreddit`)
 
 Triggered flow (via bot inbox):

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,13 @@ setup(
     keywords='',
     packages=find_packages(exclude=['test*', 'bin/*']),
     test_suite='test',
+    entry_points={
+        'console_scripts': [
+            'tor-moderator = tor.main:main',
+            'tor-apprentice = tor.ocr:main',
+            'tor-archivist = tor.archiver:main',
+        ],
+    },
     install_requires=[
         'praw==4.4.0',
         'redis<3.0.0',

--- a/tor/archiver.py
+++ b/tor/archiver.py
@@ -72,7 +72,10 @@ def run(tor, config, archive):
             logging.info('Post archived!')
 
 
-if __name__ == '__main__':
+def main():
+    '''
+    Console scripts entry point for Archiver Bot
+    '''
     r = Reddit('bot_archiver')
 
     configure_logging(config, log_name='archiver.log')
@@ -104,3 +107,7 @@ if __name__ == '__main__':
 
     except Exception as e:
         explode_gracefully('ToR_archivist', e, tor)
+
+
+if __name__ == '__main__':
+    main()

--- a/tor/main.py
+++ b/tor/main.py
@@ -55,7 +55,10 @@ def run(r, tor, config):
         time.sleep(60)
 
 
-if __name__ == '__main__':
+def main():
+    '''
+    Console scripts entry point for Moderator Bot
+    '''
     r = Reddit('bot')  # loaded from local praw.ini config file
     configure_logging(config)
 
@@ -77,3 +80,7 @@ if __name__ == '__main__':
 
     except Exception as e:
         explode_gracefully('u/ToR', e, tor)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
See changes to README for how to invoke the bots.

Realistically, this is backwards compatible with the `python tor/archiver.py` format, but this makes it so on `pip install` it adds the CLI tool to the PATH and hardcodes the version of python in the shebang. In short, it means python2 and python3 CLI tools can coexist in PATH. You also don't have to know what version of python to use.