### PR TITLE
Updates changelog to include missed releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Nothing yet...
 
 - Adds Travis CI support, enforcing support for python 3.6
 - Updates docs for `pip install` using a git url
-- Adds CLI tools `tor-moderator`, `tor-apprentice`, and `tor-archivist` to PATH (instead of `python path/to/bot.py`)
+- Adds CLI tool `tor-moderator` to PATH (instead of `python tor/main.py`)
 - Splits to multiple requirements.txt files, depending on usage
 - `python setup.py test` defers to PyTest as the framework
 - Initial attempts at automated test support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 We follow [Semantic Versioning](http://semver.org/) as a way of measuring stability of an update. This
 means we will never make a backwards-incompatible change within a major version of the project.
 
+## [Unreleased]
+
+Nothing yet...
+
+## v3.0.1 (2017-09-05)
+
+- Adds Travis CI support, enforcing support for python 3.6
+- Updates docs for `pip install` using a git url
+- Adds CLI tools `tor-moderator`, `tor-apprentice`, and `tor-archivist` to PATH (instead of `python path/to/bot.py`)
+- Splits to multiple requirements.txt files, depending on usage
+- `python setup.py test` defers to PyTest as the framework
+- Initial attempts at automated test support
+- Moves parts of `tor.strings` into `tor_core`
+- Moves flair flair helpers into `tor_core`
+- Post title is truncated if longer than 250 characters
+- Better method dependency tracking (e.g., passing `config.r` instead of whole `config`)
+
+## v3.0.0 (2017-08-20)
+
+- Updates PRAW (Reddit API) library: v4.4.0 -> v5.0.1
+- Extracts major parts of `tor.core` into [`tor_core`](https://github.com/TranscribersOfReddit/TranscribersOfReddit)
+- Moves `tor-archivist` bot to [`ToR_Archivist`](https://github.com/TranscribersOfReddit/ToR_Archivist)
+- Moves `tor-apprentice` bot to [`ToR_OCR`](https://github.com/TranscribersOfReddit/ToR_OCR)
+- Reverts dependency management change (pass entire `config` object again)
+- Disable self-update directive to bot (does not yet work)
+- Adds directive 'ping' to check if bot is alive
+- Adds 'Meta' flair for posts by author who isn't a mod or known bot
+- Rewrite `tor-moderator` to use bot framework in `tor_core`
+- Rule change to have user transcript require footer instead of header
+
 ## v2.7.1 (2017-07-01)
 
 - Modify date logic and fix config loading for archivist bot

--- a/README.md
+++ b/README.md
@@ -24,15 +24,21 @@ be, though there are some external requirements.
 
 ## Installation
 
+Make sure you have an [up-to-date copy of pip installed](https://pip.pypa.io/en/stable/installing/) and Python 3.6.
+
+Find the [latest release](https://github.com/TranscribersOfReddit/TranscribersOfReddit/releases/latest) and replace `v3.0.1` below with the more up-to-date version.
+
 ```
 $ git clone https://github.com/TranscribersOfReddit/TranscribersOfReddit.git tor
-$ pip install tor/
+$ cd tor/
+$ git checkout v3.0.1
+$ pip install .
 ```
 
 OR
 
 ```
-$ pip install 'git+https://github.com/TranscribersOfReddit/TranscribersOfReddit.git@master#egg=tor'
+$ pip install 'git+https://github.com/TranscribersOfReddit/TranscribersOfReddit.git@v3.0.1#egg=tor'
 ```
 
 ## Moderator Bot (`/u/transcribersofreddit`)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Stories in Ready](https://badge.waffle.io/itsthejoker/TranscribersOfReddit.png?label=ready&title=Ready)](http://waffle.io/itsthejoker/TranscribersOfReddit)
+[![Stories in Ready](https://badge.waffle.io/TranscribersOfReddit/TranscribersOfReddit.png?label=ready&title=Ready)](http://waffle.io/TranscribersOfReddit/TranscribersOfReddit)
 
-# Transcribers Of Reddit
+# Transcribers of Reddit
 
 This is the source code for the set of bots that run under the usernames listed
 below. Together, they all assist in the running or /r/TranscribersOfReddit, which
@@ -41,7 +41,7 @@ OR
 $ pip install 'git+https://github.com/TranscribersOfReddit/TranscribersOfReddit.git@v3.0.1#egg=tor'
 ```
 
-## Moderator Bot (`/u/transcribersofreddit`)
+## Big Picture
 
 Triggered flow (via bot inbox):
 
@@ -59,48 +59,13 @@ Monitoring daemon (via subreddit's /new feed):
     - Check against whitelist of domain filters
     - Post url to the content back to /r/TranscribersOfReddit
 
-### Running Moderator Bot
+## Usage
 
 ```
 $ tor-moderator
 # => [daemon mode + logging]
 ```
 
-## Apprentice Bot (`/u/transcribot`)
-
-Monitoring daemon (via Redis queue):
-
-- Pull job (by post id) off of queue:
-  - Download image
-  - OCR the image
-  - If OCR successful:
-    - Post OCR-ed content to post on /r/TranscribersOfReddit in 9000 character chunks
-  - Delete local copy of image
-
-### Running Apprentice Bot
-
-```
-$ tor-apprentice
-# => [daemon mode + logging]
-```
-
-## Archiver Bot (`/u/ToR_archivist`)
-
-Monitoring daemon (via subreddit's /new feed):
-
-- For each completed or unclaimed post:
-   - Retrieve in which subreddit the original post was made
-   - If the post is older than the configured amount of time for this subreddit:
-     - Remove the post
-     - If it was completed, make the same post in the archive subreddit
-
-### Running Archiver Bot
-
-```
-$ tor-archivist
-# => [daemon mode + logging]
-```
-
-# Contributing
+## Contributing
 
 See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for more.

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,6 @@ setup(
     entry_points={
         'console_scripts': [
             'tor-moderator = tor.main:main',
-            'tor-apprentice = tor.ocr:main',
-            'tor-archivist = tor.archiver:main',
         ],
     },
     tests_require=[


### PR DESCRIPTION
Looks like we haven't been too diligent on updating the changelog for each release. Now all version changes (except one flub with `2.6.14` -> `2.6.1` -> `2.7.0`) are [tagged in git](https://github.com/TranscribersOfReddit/TranscribersOfReddit/tags).

This PR is a followup by attempting to describe the changes between `v2.7.1` -> `v3.0.0` and between `v3.0.0` -> `v3.0.1`

Also prunes stale `console_scripts` in `setup.py`.