### PR TITLE
The PM Update: Convert username mentions to PMs instead

### DIFF
--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -75,16 +75,9 @@ def check_inbox(config):
     for mention in mentions:
         logging.info('Received mention! ID {}'.format(mention))
 
-        if not is_valid(mention.parent_id, config):
-            # Do our check here to make sure we can actually work on this one and
-            # that we haven't already posted about it. We use the full ID here
-            # instead of the cleaned one, just in case.
-            logging.info(id_already_handled_in_db.format(mention.parent_id))
-            continue
-
         # noinspection PyUnresolvedReferences
         try:
-            process_mention(mention, config)
+            process_mention(mention)
         except (AttributeError, praw.exceptions.ClientException):
             # apparently this crashes with an AttributeError if someone calls
             # the bot and immediately deletes their comment. This should fix

--- a/tor/core/mentions.py
+++ b/tor/core/mentions.py
@@ -1,95 +1,20 @@
 import logging
 
+from tor.strings.responses import pm_body
+from tor.strings.responses import pm_subject
 # noinspection PyProtectedMember
 from tor_core.helpers import _
-from tor_core.helpers import clean_id
-from tor_core.strings import reddit_url
-
-from tor.helpers.flair import flair
-from tor.helpers.flair import flair_post
-from tor.helpers.reddit_ids import add_complete_post_id
-from tor.helpers.reddit_ids import is_valid
-from tor.strings.posts import rules_comment_unknown_format
-from tor.strings.posts import summoned_by_comment
-from tor.strings.posts import summoned_submit_title
-from tor.strings.responses import something_went_wrong
 
 
-def process_mention(mention, config):
+def process_mention(mention):
     """
     Handles username mentions and handles the formatting and posting of
     those calls as workable jobs to ToR.
 
     :param mention: the Comment object containing the username mention.
-    :param config: the global config dict
     :return: None.
     """
 
-    # We have to do this entire parent / parent_permalink thing twice because
-    # the method for calling a permalink changes for each object. Laaaame.
-    if not mention.is_root:
-        # this comment is in reply to something. Let's grab a comment object.
-        parent = config.r.comment(id=clean_id(mention.parent_id))
-        parent_permalink = parent.permalink()
-        # a comment does not have a title attribute. Let's fake one by giving
-        # it something to work with.
-        parent.title = 'Unknown Content'
-    else:
-        # this is a post.
-        parent = config.r.submission(id=clean_id(mention.link_id))
-        parent_permalink = parent.permalink
-        # format that sucker so it looks right in the template.
-        parent.title = '"' + parent.title + '"'
-
-        # Ignore requests made by the OP of content or the OP of the submission
-        if mention.author == parent.author:
-            logging.info(
-                'Ignoring mention by OP u/{} on ID {}'.format(mention.author,
-                                                              mention.parent_id)
-            )
-            return
-
-    logging.info(
-        'Posting call for transcription on ID {}'.format(mention.parent_id)
-    )
-
-    if is_valid(parent.fullname, config):
-        # we're only doing this if we haven't seen this one before.
-
-        # noinspection PyBroadException
-        try:
-            result = config.tor.submit(
-                title=summoned_submit_title.format(
-                    sub=mention.subreddit.display_name,
-                    commentorpost=parent.__class__.__name__.lower(),
-                    title=parent.title
-                ),
-                url=reddit_url.format(parent_permalink)
-            )
-            result.reply(_(rules_comment_unknown_format.format(header=config.header)))
-            result.reply(_(
-                summoned_by_comment.format(
-                    reddit_url.format(
-                        config.r.comment(
-                            clean_id(mention.fullname)
-                        ).permalink()
-                    )
-                )
-            ))
-            flair_post(result, flair.summoned_unclaimed)
-            logging.debug(
-                'Posting success message in response to caller, u/{}'.format(mention.author)
-            )
-            mention.reply(_(
-                'The transcribers have been summoned! Please be patient '
-                'and we\'ll be along as quickly as we can.')
-            )
-            add_complete_post_id(parent.fullname, config)
-
-            # I need to figure out what errors can happen here
-        except Exception as e:
-            logging.error(
-                '{} - Posting failure message in response to caller, '
-                'u/{}'.format(e, mention.author)
-            )
-            mention.reply(_(something_went_wrong))
+    # message format is subject, then body
+    mention.author.message(pm_subject, _(pm_body))
+    logging.info('Message sent to {}!'.format(mention.author.name))

--- a/tor/strings/posts.py
+++ b/tor/strings/posts.py
@@ -1,7 +1,3 @@
-summoned_submit_title = (
-    '{sub} | {title} | We\'ve been summoned for a {commentorpost}!'
-)
-
 discovered_submit_title = (
     '{sub} | {type} | "{title}"'
 )
@@ -22,33 +18,6 @@ rules_comment = (
     '(https://www.reddit.com/message/'
     'compose?to=%2Fr%2FTranscribersOfReddit&subject=General%20Question'
     '&message=)'
-)
-
-rules_comment_unknown_format = (
-    'If you would like to claim this post, please respond to this comment '
-    'with the word `claiming` or `claim` in your response. I will automatically '
-    'update the flair so that only one person is working on a post at any given '
-    'time.'
-    '\n\nWhen you\'re done, please comment again with `done`. Your flair will '
-    'be updated to reflect the number of posts you\'ve transcribed and the '
-    'will be marked as completed.'
-    '\n\nWe do not know what type of formatting the above post has, but if '
-    'one of the mods finds it we will update this comment. Otherwise please '
-    'refer to the sidebar for further information.\n\n---'
-    '\n\nFooter\n---\n\nWhen you\'re done, please put the following footer at '
-    'the bottom of your post:\n\n---\n\n{header}\n\n---'
-    '\n\nIf you have any questions, feel free to [message the mods.]'
-    '(https://www.reddit.com/message/'
-    'compose?to=%2Fr%2FTranscribersOfReddit&Ssubject=General%20Question'
-    '&message=)'
-)
-
-summoned_by_comment = (
-    'We were summoned by a comment to look at the above content. When you\'re '
-    'done with the post, please post it as a reply to the poster who requested '
-    'our services; [their comment can be found here.]({})\n\n'
-    'This post will not be counted as `Done` if you reply to the main post; you '
-    '*must* reply to the post which summoned us.'
 )
 
 yt_already_has_transcripts = (

--- a/tor/strings/responses.py
+++ b/tor/strings/responses.py
@@ -68,3 +68,18 @@ thumbs_up_gifs = [
 youre_welcome = (
     '[Hey, you\'re welcome!]({})'
 )
+
+pm_subject = (
+    'Username Call'
+)
+
+pm_body = (
+    'Hi there! Thanks for pinging me!\n\n'
+    'Due to some changes with how Reddit and individual subreddits handle bots, I can\'t '
+    'be summoned directly to your comment anymore. If there\'s something that you would like '
+    'assistance with, please post a link to that content on /r/DescriptionPlease, '
+    'and one of our lovely volunteers will be along shortly.\n\n'
+    'Thanks for using our services! We hope we can make your day a little bit better :)\n\n'
+    'Cheers,\n\n'
+    'The Mods of /r/TranscribersOfReddit'
+)


### PR DESCRIPTION
Right now, if you ping u/transcribersofreddit, it will automatically format and create a post on r/ToR. Due to the possibility of the bot being banned in any sub where it's called, we're converting this to PM a user instead, telling them to please make a post on r/DescriptionPlease.

Once they post there, it will automatically get crossposted to r/ToR as part of the normal operations. This also opens up a new avenue and some better integration with r/blind and their members.