### PR TITLE
Partner PR for 3.1.0: Invert Inbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ means we will never make a backwards-incompatible change within a major version 
 Nothing yet...
 
 ## v3.1.0 (2017-10-14)
+- Now processing inbox messages in the correct order
 - Adds support for pulling all submissions from specific subreddits
 
 ## v3.0.3 (2017-10-01)

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -30,8 +30,9 @@ def check_inbox(config):
     # Sort inbox, then act on it
     mentions = []
     replies = []
-    # grab all of our messages and filter
-    for item in config.r.inbox.unread(limit=None):
+    # Grab all of our messages and filter.
+    # Invert the inbox so we're processing oldest first!
+    for item in reversed(list(config.r.inbox.unread(limit=None))):
         # Very rarely we may actually get a message from Reddit itself.
         # In this case, there will be no author attribute.
         if item.author is None:


### PR DESCRIPTION
Right now, the inbox pulls in the default PRAW method, which is newest to oldest. If the bot is offline for some amount of time and responses are allowed to build up, that means that "done" comments will be processed before "claim" comments.

This change pulls all the unread messages, puts them in a list, inverts the list, and then processes from oldest to newest.