### PR TITLE
Mod help needed comments

### DIFF
--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -82,32 +82,32 @@ def check_inbox(config):
                 ''.format(item.subject), config
             )
             item.mark_read()
-            continue
 
-        if item.author.name == 'transcribot':
+        elif item.author.name == 'transcribot':
             item.mark_read()
-            continue
-        if item.subject == 'username mention':
+
+        elif item.subject == 'username mention':
             mentions.append(item)
             item.mark_read()
-        if item.subject in ('comment reply', 'post reply'):
+
+        elif item.subject in ('comment reply', 'post reply'):
             replies.append(item)
             # we don't mark as read here so that any comments that are not
             # ones we're looking for will eventually get emailed to me as
             # things I need to look at
-        if 'reload' in item.subject.lower():
+
+        elif 'reload' in item.subject.lower():
             item.mark_read()
             reload_config(item, config)
 
-            continue
-        if 'update' in item.subject.lower():
+        elif 'update' in item.subject.lower():
             item.mark_read()
             update_and_restart(item, config)
             # there's no reason to do anything else here because the process
             # will terminate and respawn
 
         # ARE YOU ALIVE?!
-        if item.subject.lower() == 'ping':
+        elif item.subject.lower() == 'ping':
             item.mark_read()
             logging.info('Received ping from {}. Pong!'.format(item.author.name))
             item.reply('Pong!')

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import praw
 from tor_core.helpers import send_to_slack
@@ -11,6 +12,14 @@ from tor.core.user_interaction import process_claim
 from tor.core.user_interaction import process_coc
 from tor.core.user_interaction import process_done
 from tor.core.user_interaction import process_thanks
+
+
+MOD_SUPPORT_PHRASES = [
+    re.compile('fuck', re.IGNORECASE),
+    re.compile('unclaim', re.IGNORECASE),
+    re.compile('undo', re.IGNORECASE),
+    re.compile('(?:good|bad) bot', re.IGNORECASE),
+]
 
 
 def check_inbox(config):
@@ -106,10 +115,15 @@ def check_inbox(config):
                 reply.mark_read()
                 return
 
+            if any([regex.search(reply.body) for regex in MOD_SUPPORT_PHRASES]):
+                # TODO: Handle message
+                pass
+
             if '!override' in reply.body.lower():
                 process_override(reply, config)
                 reply.mark_read()
                 return
+
             if 'good bot' in reply.body.lower() or 'bad bot' in reply.body.lower():
                 # please stop emailing me, I just don't care
                 reply.mark_read()

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -11,8 +11,6 @@ from tor.core.user_interaction import process_claim
 from tor.core.user_interaction import process_coc
 from tor.core.user_interaction import process_done
 from tor.core.user_interaction import process_thanks
-from tor.helpers.reddit_ids import is_valid
-from tor.strings.debug import id_already_handled_in_db
 
 
 def check_inbox(config):


### PR DESCRIPTION
This covers the use case where someone tries to "unclaim" a post, while simultaneously laying the ground-work for notifying mods in slack if a comment needs mod-attention.